### PR TITLE
Tuning coherencies kernel

### DIFF
--- a/predict_model.cu
+++ b/predict_model.cu
@@ -633,14 +633,14 @@ kernel_coherencies_slave(int sta1, int sta2, int itm, int B, int N, int T, int K
   /* add up to form final result */
   if (threadIdx.x==0) {
     for(int cf=0; cf<F; cf++) {
-     coh[cf*8*B]=tmpcoh[8*cf];
-     coh[cf*8*B+1]=tmpcoh[8*cf+1];
-     coh[cf*8*B+2]=tmpcoh[8*cf+2];
-     coh[cf*8*B+3]=tmpcoh[8*cf+3];
-     coh[cf*8*B+4]=tmpcoh[8*cf+4];
-     coh[cf*8*B+5]=tmpcoh[8*cf+5];
-     coh[cf*8*B+6]=tmpcoh[8*cf+6];
-     coh[cf*8*B+7]=tmpcoh[8*cf+7];
+     coh[cf*8*B]+=tmpcoh[8*cf];
+     coh[cf*8*B+1]+=tmpcoh[8*cf+1];
+     coh[cf*8*B+2]+=tmpcoh[8*cf+2];
+     coh[cf*8*B+3]+=tmpcoh[8*cf+3];
+     coh[cf*8*B+4]+=tmpcoh[8*cf+4];
+     coh[cf*8*B+5]+=tmpcoh[8*cf+5];
+     coh[cf*8*B+6]+=tmpcoh[8*cf+6];
+     coh[cf*8*B+7]+=tmpcoh[8*cf+7];
     }
   }
 }

--- a/predict_model.cu
+++ b/predict_model.cu
@@ -561,7 +561,9 @@ kernel_coherencies_slave(int sta1, int sta2, int itm, int B, int N, int T, int K
      if (dobeam) {
       /* get beam info */
       //int boffset1=sta1*K*T*F + k1*T*F + cf*T + itm;
+
       int boffset1=itm*N*K*F+k1*N*F+cf*N+sta1;
+      //  printf("itm=%d, k1=%d, sta1=%d, sta2=%d, boffset1=%d, boffset2=%d\n", itm, k1, sta1, sta2, boffset1, boffset2);
       float beam1=__ldg(&beam[boffset1]);
       //int boffset2=sta2*K*T*F + k1*T*F + cf*T + itm;
       int boffset2=itm*N*K*F+k1*N*F+cf*N+sta2;
@@ -644,6 +646,7 @@ kernel_coherencies_slave(int sta1, int sta2, int itm, int B, int N, int T, int K
 }
 
 /* master kernel to calculate coherencies */
+extern "C"
 __global__ void 
 kernel_coherencies(int B, int N, int T, int K, int F,float *u, float *v, float *w,baseline_t *barr, float *freqs, float *beam, float *ll, float *mm, float *nn, float *sI,
   unsigned char *stype, float *sI0, float *f0, float *spec_idx, float *spec_idx1, float *spec_idx2, int **exs, float deltaf, float deltat, float dec0, float *coh, int dobeam) {
@@ -663,7 +666,7 @@ kernel_coherencies(int B, int N, int T, int K, int F,float *u, float *v, float *
    cudaError_t error;
 #endif
 
-   int ThreadsPerBlock=DEFAULT_TH_PER_BK;
+   int ThreadsPerBlock= block_size_x; //DEFAULT_TH_PER_BK;
    /* each slave thread will calculate one source, 8xF values for all freq */
    /* also give right offset for coherencies */
    if (K<ThreadsPerBlock) {

--- a/predict_model.cu
+++ b/predict_model.cu
@@ -497,38 +497,11 @@ shapelet_contrib(int *dd, float u, float v, float w) {
 }
 
 
+__device__ cuFloatComplex compute_prodterm(int sta1, int sta2, int N, int K, int T, int F,
+float phterm0, float sIf, float sI0f, float spec_idxf, float spec_idx1f, float spec_idx2f, float myf0,
+const float *__restrict__ freqs, float deltaf, int dobeam, int itm, int k1, int cf, float *beam, int **exs, unsigned char stypeT,
+float u, float v, float w, int k) {
 
-/* slave thread to calculate coherencies, for 1 source */
-/* baseline (sta1,sta2) at time itm */
-/* K: total sources, uset to find right offset 
-   Kused: actual sources calculated in this thread block
-   Koff: offset in source array to start calculation
-   NOTE: only 1 block is used
- */
-__global__ void 
-kernel_coherencies_slave(int sta1, int sta2, int itm, int B, int N, int T, int K, int Kused, int Koff, int F, float u, float v, float w, float *freqs, float *beam, float *ll, float *mm, float *nn, float *sI,
-  unsigned char *stype, float *sI0, float *f0, float *spec_idx, float *spec_idx1, float *spec_idx2, int **exs, float deltaf, float deltat, float dec0, float *__restrict__ coh,int dobeam,int blockDim_2) {
-  /* which source we work on */
-  unsigned int k=threadIdx.x+blockDim.x*blockIdx.x;
-
-  extern __shared__ float tmpcoh[]; /* assumed to be size 8*F*Kusedx1 */
-
-  if (k<Kused) {
-   int k1=k+Koff; /* actual source id */
-   /* preload all freq independent variables */
-   /* Fourier phase */
-   float phterm0=2.0f*M_PI*(u*__ldg(&ll[k])+v*__ldg(&mm[k])+w*__ldg(&nn[k]));
-   float sIf,sI0f,spec_idxf,spec_idx1f,spec_idx2f,myf0;
-   sIf=__ldg(&sI[k]);
-   if (F>1) {
-     sI0f=__ldg(&sI0[k]);
-     spec_idxf=__ldg(&spec_idx[k]);
-     spec_idx1f=__ldg(&spec_idx1[k]);
-     spec_idx2f=__ldg(&spec_idx2[k]);
-     myf0=__ldg(&f0[k]);
-   }
-   unsigned char stypeT=__ldg(&stype[k]);
-   for(int cf=0; cf<F; cf++) {
      float sinph,cosph;
      float myfreq=__ldg(&freqs[cf]);
      sincosf(phterm0*myfreq,&sinph,&cosph);
@@ -591,6 +564,53 @@ kernel_coherencies_slave(int sta1, int sta2, int itm, int B, int N, int T, int K
       }
      }
      
+
+    return prodterm;
+
+}
+
+
+/* slave thread to calculate coherencies, for 1 source */
+/* baseline (sta1,sta2) at time itm */
+/* K: total sources, uset to find right offset 
+   Kused: actual sources calculated in this thread block
+   Koff: offset in source array to start calculation
+   NOTE: only 1 block is used
+ */
+__global__ void 
+kernel_coherencies_slave(int sta1, int sta2, int itm, int B, int N, int T, int K, int Kused, int Koff, int F,
+    float u, float v, float w, const float *freqs, float *beam, const float *ll, const float *mm, const float *nn, const float *sI,
+    const unsigned char *stype, const float *sI0, const float *f0, const float *spec_idx, const float *spec_idx1, const float *spec_idx2,
+    int **exs, float deltaf, float deltat, float dec0, float *__restrict__ coh, int dobeam, int blockDim_2) {
+  /* which source we work on */
+  unsigned int k=threadIdx.x+blockDim.x*blockIdx.x;
+
+  extern __shared__ float tmpcoh[]; /* assumed to be size 8*F*Kusedx1 */
+
+  if (k<Kused) {
+
+   int k1=k+Koff; /* actual source id */
+
+   /* preload all freq independent variables */
+   /* Fourier phase */
+   float phterm0=2.0f*M_PI*(u*__ldg(&ll[k])+v*__ldg(&mm[k])+w*__ldg(&nn[k]));
+   float sIf,sI0f,spec_idxf,spec_idx1f,spec_idx2f,myf0;
+   sIf=__ldg(&sI[k]);
+   if (F>1) {
+     sI0f=__ldg(&sI0[k]);
+     spec_idxf=__ldg(&spec_idx[k]);
+     spec_idx1f=__ldg(&spec_idx1[k]);
+     spec_idx2f=__ldg(&spec_idx2[k]);
+     myf0=__ldg(&f0[k]);
+   }
+   unsigned char stypeT=__ldg(&stype[k]);
+   for(int cf=0; cf<F; cf++) {
+
+
+    cuFloatComplex prodterm = compute_prodterm(sta1, sta2, N, K, T, F,
+phterm0, sIf, sI0f, spec_idxf, spec_idx1f, spec_idx2f, myf0, freqs, deltaf, dobeam, itm, k1, cf, beam, exs, stypeT, u, v, w, k);
+
+
 //printf("k=%d cf=%d freq=%f uvw %f,%f,%f lmn %f,%f,%f phterm %f If %f\n",k,cf,freqs[cf],u,v,w,ll[k],mm[k],nn[k],phterm,If);
 
      /* write output to shared array */
@@ -648,8 +668,11 @@ kernel_coherencies_slave(int sta1, int sta2, int itm, int B, int N, int T, int K
 /* master kernel to calculate coherencies */
 extern "C"
 __global__ void 
-kernel_coherencies(int B, int N, int T, int K, int F,float *u, float *v, float *w,baseline_t *barr, float *freqs, float *beam, float *ll, float *mm, float *nn, float *sI,
-  unsigned char *stype, float *sI0, float *f0, float *spec_idx, float *spec_idx1, float *spec_idx2, int **exs, float deltaf, float deltat, float dec0, float *coh, int dobeam) {
+kernel_coherencies(int B, int N, int T, int K, int F, float *u, float *v, float *w, baseline_t *barr, float *freqs, float *beam,
+    const float *__restrict__ ll, const float *__restrict__ mm, const float *__restrict__ nn,
+    const float *__restrict__ sI, const unsigned char *__restrict__ stype,
+    const float *__restrict__ sI0, const float *__restrict__ f0,
+    const float *__restrict__ spec_idx, const float *__restrict__ spec_idx1, const float *__restrict__ spec_idx2, int **exs, float deltaf, float deltat, float dec0, float *coh, int dobeam) {
 
   /* global thread index */
   unsigned int n=threadIdx.x+blockDim.x*blockIdx.x;
@@ -661,6 +684,8 @@ kernel_coherencies(int B, int N, int T, int K, int F,float *u, float *v, float *
    /* find out which time slot this baseline is from */
    int tslot=n/((N*(N-1)/2));
 
+
+    #if use_kernel == 1
 
 #ifdef CUDA_DBG
    cudaError_t error;
@@ -705,8 +730,64 @@ kernel_coherencies(int B, int N, int T, int K, int F,float *u, float *v, float *
     }
    }
 
-  }
+    #else //use_kernel == 0
 
+    float u_n = u[n];
+    float v_n = v[n];
+    float w_n = w[n];
+
+    //TODO: figure out if this max_f makes any sense
+    #define MAX_F 20
+    cuFloatComplex l_coh[MAX_F];
+    for(int cf=0; cf<F; cf++) {
+        l_coh[cf] = make_cuFloatComplex(0.0f, 0.0f);
+    }
+
+    //use simply for-loop, if K is very large this may be slow and may need further parallelization
+    for (int k=0; k<K; k++) {
+
+        //source specific params
+        float phterm0 = 0.0f;
+        float sIf,sI0f,spec_idxf,spec_idx1f,spec_idx2f,myf0;
+
+        phterm0 = 2.0f*M_PI*(u_n*__ldg(&ll[k])+v_n*__ldg(&mm[k])+w_n*__ldg(&nn[k]));
+        sIf=__ldg(&sI[k]);
+        if (F>1) {
+            sI0f=__ldg(&sI0[k]);
+            spec_idxf=__ldg(&spec_idx[k]);
+            spec_idx1f=__ldg(&spec_idx1[k]);
+            spec_idx2f=__ldg(&spec_idx2[k]);
+            myf0=__ldg(&f0[k]);
+        }
+
+        unsigned char stypeT=__ldg(&stype[k]);
+
+        for(int cf=0; cf<F; cf++) {
+            l_coh[cf] = cuCaddf(l_coh[cf], compute_prodterm(sta1, sta2, N, K, T, F, phterm0, sIf, sI0f, spec_idxf, spec_idx1f, spec_idx2f,
+                                myf0, freqs, deltaf, dobeam, tslot, k, cf, beam, exs, stypeT, u_n, v_n, w_n, k));
+        }
+
+    }
+
+    //write output
+    coh = &coh[8*n];
+    for(int cf=0; cf<F; cf++) {
+
+        coh[cf*8*B+0] = l_coh[cf].x;
+        coh[cf*8*B+1] = l_coh[cf].y;
+        coh[cf*8*B+2] = 0.0f;
+        coh[cf*8*B+3] = 0.0f;
+        coh[cf*8*B+4] = 0.0f;
+        coh[cf*8*B+5] = 0.0f;
+        coh[cf*8*B+6] = l_coh[cf].x;
+        coh[cf*8*B+7] = l_coh[cf].y;
+
+    }
+
+
+    #endif
+
+  }
 }
 
 

--- a/predict_model.h
+++ b/predict_model.h
@@ -35,7 +35,7 @@ typedef struct exinfo_ring_ {
 
 typedef struct exinfo_shapelet_ {
   int n0; /* model order, no of modes=n0*n0 */
-  double beta; /* scale*/
+  double beta; /* scale */
   double *modes; /* array of n0*n0 x 1 values */
   double eX,eY,eP; /* linear transform parameters */
 

--- a/tune_kernel_array_beam.py
+++ b/tune_kernel_array_beam.py
@@ -126,16 +126,17 @@ def tune():
 
     N = 61
     T = 200
-    K = 150
+    #K = 150
+    K = 5000
     F = 10
 
     problem_size = (T*K*F, N)
 
     args = generate_input_data(N, T, K, F)
 
-    ref = call_reference_kernel(N, T, K, F, args, cp)
+    #ref = call_reference_kernel(N, T, K, F, args, cp)
 
-    print(ref[17][:20])
+    #print(ref[17][:20])
 
     tune_params = OrderedDict()
     tune_params["block_size_x"] = [2**i for i in range(5,11)]
@@ -144,7 +145,7 @@ def tune():
 
     #restrict = ["use_kernel == 0 or block_size_x<=64"]
     results, env = tune_kernel("kernel_tuner_host_array_beam", [get_kernel_path()+"predict_model.cu"], problem_size, args, tune_params,
-                lang="C", compiler_options=cp, verbose=True, answer=ref)
+                lang="C", compiler_options=cp, verbose=True ) #, answer=ref)
 
     return results
 

--- a/tune_kernel_coherencies.py
+++ b/tune_kernel_coherencies.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+
+import itertools
+from collections import OrderedDict
+import os
+
+import numpy as np
+from kernel_tuner import tune_kernel, run_kernel
+
+def get_kernel_path():
+    """ get path to the kernels as a string """
+    return str(os.path.dirname(os.path.realpath(__file__)))+'/'
+
+cp = ["-rdc=true", "-I"+get_kernel_path(), "-Xptxas=-v"] #, "-maxrregcount=32"] #, "-Xptxas=-v"]
+
+
+def generate_input_data(B, N, T, K, F):
+    """ generate random input to calculate coherencies
+    B: total baselines
+    N: no of stations
+    T: no of time slots
+    K: no of sources
+    F: no of frequencies
+    u,v,w: Bx1 uvw coords
+    barr: Bx1 array of baseline/flag info
+    freqs: Fx1 frequencies
+    beam: NxTxKxF beam gain
+    ll,mm,nn : Kx1 source coordinates
+    sI: Kx1 source flux at reference freq
+    stype: Kx1 source type info
+    sI0: Kx1 original source referene flux
+    f0: Kx1 source reference freq for calculating flux
+    spec_idx,spec_idx1,spec_idx2: Kx1 spectra info
+    exs: Kx1 array of pointers to extended source info
+    deltaf,deltat: freq/time smearing integration interval
+    dec0: phace reference dec
+    coh: coherency Bx8 values, all K sources are added together
+    dobeam: enable beam if >0
+    """
+
+    u,v,w = (np.random.randn(3, B)).astype(np.float32)
+
+    #you would think that the baseline_t struct is 9 bytes, but the compiler pads it to 12
+    #baseline = np.dtype([('int1', np.int32, 1), ('int2', np.int32, 1), ('flag', np.uint8, (1))])
+    baseline = np.dtype([('int1', '<u4'), ('int2', '<u4'), ('flag', '<u4')])
+    barr = np.zeros(B).astype(baseline)
+    baselines = np.array(list(itertools.combinations(range(N), r=2)))
+    barr['int1'] = list(baselines[:,0]) * T
+    barr['int2'] = list(baselines[:,1]) * T
+    barr['flag'] = (1.2*np.random.rand(B)).astype(np.uint32)
+
+    eps = 1e-6 #used to avoid zero values
+
+    freqs = eps+np.absolute(np.random.randn(F).astype(np.float32))
+    beam = np.random.randn(N*K*T*F).astype(np.float32)
+
+    #source info
+    ll,mm,nn = (np.random.randn(3, K)).astype(np.float32)
+    sI = eps+np.absolute(np.random.randn(K).astype(np.float32))
+    sI0 = eps+np.absolute(np.random.randn(K).astype(np.float32))
+    f0 = eps+np.absolute(np.random.randn(K).astype(np.float32))
+    spec_idx,spec_idx1,spec_idx2 = eps+np.absolute(1e-5*np.random.randn(3, K).astype(np.float32))
+
+    #for the moment assume only point sources
+    stype = np.zeros(K).astype(np.uint8)
+    #stype = (5.0*np.random.rand(K)).astype(np.uint8)
+    exs = np.zeros(1).astype(np.int64) #this should be an array of pointers to exinfo_ structs
+
+    deltaf, deltat = eps+np.absolute(np.random.randn(2).astype(np.float32))
+    dec0 = np.random.randn(1).astype(np.float32)
+
+    #the output
+    coh = np.zeros(8*B*F).astype(np.float32)
+
+    dobeam = np.int32(1)
+
+    return (np.int32(B), np.int32(N), np.int32(T), np.int32(K), np.int32(F), u,v,w, barr, freqs, beam,
+            ll,mm,nn, sI, stype, sI0, f0, spec_idx,spec_idx1,spec_idx2, exs, deltaf, deltat, dec0, coh, dobeam)
+
+
+
+def call_reference_kernel(N, B, T, K, F, args):
+
+    problem_size = B
+
+    params = {'block_size_x': 32, "use_kernel": 1}
+    answer = run_kernel("kernel_coherencies", get_kernel_path()+"predict_model.cu",
+                               problem_size, args, params, compiler_options=cp)
+
+    return answer
+
+
+def tune():
+
+    N = 61
+    T = 200
+    K = 150
+    F = 10
+    B = (N)*(N-1)//2 * T
+
+    print('N', N, 'B', B, 'T', T, 'K', K, 'F', F)
+
+    args = generate_input_data(B, N, T, K, F)
+
+    problem_size = B
+
+    tune_params = OrderedDict()
+    tune_params['block_size_x'] = [2**i for i in range(5,11)]
+    tune_params['use_kernel'] = [0]
+
+    ref = call_reference_kernel(N, B, T, K, F, args)
+
+    answer = [None for _ in args]
+    answer[-2] = ref[-2]
+
+    print("With slave kernel:")
+    tune_kernel("kernel_coherencies", get_kernel_path()+"predict_model.cu",
+                               problem_size, args, {'block_size_x': [32], 'use_kernel': [1]}, compiler_options=cp, verbose=True, answer=answer, atol=1e-5)
+
+
+    print("Without slave kernel:")
+    results, env = tune_kernel("kernel_coherencies", get_kernel_path()+"predict_model.cu",
+                               problem_size, args, tune_params, compiler_options=cp, verbose=True, answer=answer, atol=1e-5)
+
+    return results
+
+
+if __name__ == "__main__":
+
+    tune()
+


### PR DESCRIPTION
split part of the slave kernel into a device function
introduced tunable parameter 'use_kernel' to the master coherencies kernel
if use_kernel == 1 the master kernel calls the slave kernel
if use_kernel == 0 the master kernel uses a for-loop over K instead

the input data in the tuning script is random and as such there may still be small errors that we can't detect right now, testing with better data is needed.

the tuning script also assumes that all sources are point sources, if more complex sources are used we may run into diverge issues for which we can use more sophisticated methods (gpu-mulitisplit for example). Whether anything like that is needed depends on the diversity among sources and how they are sorted.